### PR TITLE
Rename Enumerable DistinctBy  to DistinctRowsBy

### DIFF
--- a/sources/Myce.Extensions/EnumerableExtensions.cs
+++ b/sources/Myce.Extensions/EnumerableExtensions.cs
@@ -61,7 +61,7 @@
       /// <param name="enumerable">The enumerable</param>
       /// <param name="keySelector">The distinct property</param>
       /// <returns></returns>
-      public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> enumerable, Func<TSource, TKey> keySelector)
+      public static IEnumerable<TSource> DistinctRowsBy<TSource, TKey>(this IEnumerable<TSource> enumerable, Func<TSource, TKey> keySelector)
       {
          HashSet<TKey> seenKeys = new HashSet<TKey>(enumerable.Count());
          foreach (TSource element in enumerable)

--- a/sources/Myce.Extensions/Myce.Extensions.csproj
+++ b/sources/Myce.Extensions/Myce.Extensions.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>$(VersionPrefix)0.5.0</Version>
+		<Version>$(VersionPrefix)0.5.1</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>MYCE (Makes Your Coding Easier) Extensions is a Nuget package for Visual Studio that contains a set of extensions for the most common types.</Title>
 		<Authors>Fernando Prass</Authors>

--- a/sources/Myce.Extensions/readme.md
+++ b/sources/Myce.Extensions/readme.md
@@ -35,7 +35,7 @@ MYCE (Makes Your Coding Easier) is a Nuget package for Visual Studio that contai
 - EnumerableExtensions
     - Chunk() - Splits an enumerable into chunks of a specified size
     - ContainsDuplicates() - Return true the if the enumerable constains a duplicate element
-    - DistinctBy() - Return an enumerable of elements distinct by specific property
+    - DistinctRowsBy() - Return an enumerable of elements distinct by specific property
     - ForEach<T>() - The foreach loop
     - GetDuplicates() - Return the duplicate elements in an enumerable
     - HasData() - Return true the if the enumerable object is not null and has any record
@@ -68,6 +68,9 @@ MYCE (Makes Your Coding Easier) is a Nuget package for Visual Studio that contai
     - RemoveSimbols() Remove simbols keeping only numbers, letters and spaces (if asked)
     - RemoveAccents() - Remove accents
     - ToEnum() - Converts string to Enum object
+
+## Notes
+- In version 0.5.1 the Enumerable Extension *DistinctBy* was renamed to *DistinctRowsBy* to avoid the exception *"CS0121 The call is ambiguous between the following methods or properties..."*.
 
 ## Dependencies
 - None

--- a/tests/Myce.Extensions.Tests/EnumerableExtensionTests.cs
+++ b/tests/Myce.Extensions.Tests/EnumerableExtensionTests.cs
@@ -79,7 +79,7 @@ namespace Myce.Extensions.Tests
       {
          var list = MockData.GetListOfPeopleWithDuplicateNames();
 
-         var result = list.DistinctBy(x => x.Name);
+         var result = list.DistinctRowsBy(x => x.Name);
          Assert.Equal(2, result.Count());
          Assert.Equal("Paul", result.First().Name);
          Assert.Equal("John", result.Last().Name);


### PR DESCRIPTION
Enumerable Extension **_DistinctBy_** was renamed to **_DistinctRowsBy_** to avoid the exception "CS0121 The call is ambiguous between the following methods or properties...".
